### PR TITLE
Added NOTIFICATION_SYSTEM_CREATORS & NOTIFICATION_SYSTEM_HANDLERS as required Settings to the documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -34,6 +34,14 @@ Make the following additions to your Django settings.
                     ...
                 ]
 
+                # A list of locations for the system to search for notification creators.
+                # You can just create the list and leave it empty if you want to just put this in place.
+                NOTIFICATION_SYSTEM_CREATORS = []
+
+                # A list of locations for the system to search for notification handlers.
+                # You can just create the list and leave it empty if you want to just put this in place.
+                NOTIFICATION_SYSTEM_HANDLERS = []
+
                 # Twilio Required settings, if you're not planning on using Twilio 
                 # these can be set to empty strings
                 NOTIFICATION_SYSTEM_TARGETS={


### PR DESCRIPTION
I noticed that the notification processing is not working without setting these two options in the settings. For me they need to be declared, even as empty lists. 

If this is an exception that only occurs with me, then just ignore my changes and the PR.