### PR TITLE
Changed dependencies to work with newest Django Release (>=3.1.3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.1.3
+Django>=3.1.3
 
 html2text==2018.1.9
 twilio==6.29.1

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     # For an analysis of "install_requires" vs pip's requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=[
-        'Django==3.1.3',
+        'Django>=3.1.3',
         'html2text==2018.1.9',
         'twilio==6.29.1',
         'exponent_server_sdk==0.3.1']


### PR DESCRIPTION
I modified the dependencies to work with the Django 3.1.3 **or higher** . 
With this modification the project is matching the declared requirements in the documentation:

> 
```
Requirements
* Python (3.5, 3.6, 3.7, 3.8)
* Django (3.1+)
We highly recommend and only officially support the latest patch release of each Python and Django series.
```

Since now it is **only** working with Django 3.1.3 but no newer releases which will probably lead to dependency issues in the future. 