### PR TITLE
Remove unique constrain from 'extra' field

### DIFF
--- a/django_notification_system/management/commands/create_email_target_user_records.py
+++ b/django_notification_system/management/commands/create_email_target_user_records.py
@@ -36,4 +36,4 @@ class Command(BaseCommand):
                     },
                 )
             else:
-                print(f"{user.username} has no email address on record.")
+                print(f"{user} has no email address on record.")

--- a/django_notification_system/management/commands/process_notifications.py
+++ b/django_notification_system/management/commands/process_notifications.py
@@ -76,7 +76,7 @@ class Command(BaseCommand):
         # Loop through each notification and attempt to push it
         for notification in notifications:
             print(
-                f"{notification.target_user_record.user.username} - {notification.scheduled_delivery} - {notification.status}")
+                f"{notification.target_user_record.user} - {notification.scheduled_delivery} - {notification.status}")
             print(f"{notification.title} - {notification.body}")
 
             if not notification.target_user_record.active:

--- a/django_notification_system/migrations/0001_initial.py
+++ b/django_notification_system/migrations/0001_initial.py
@@ -88,6 +88,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AlterUniqueTogether(
             name='notification',
-            unique_together={('target_user_record', 'scheduled_delivery', 'title', 'extra')},
+            unique_together={('target_user_record', 'scheduled_delivery', 'title')},
         ),
     ]

--- a/django_notification_system/models/notification.py
+++ b/django_notification_system/models/notification.py
@@ -82,7 +82,7 @@ class Notification(CreatedModifiedAbstractModel):
 
     def __str__(self):
         return "{} - {} - {}".format(
-            self.target_user_record.user.username,
+            self.target_user_record.user,
             self.status,
             self.scheduled_delivery,
         )

--- a/django_notification_system/models/notification.py
+++ b/django_notification_system/models/notification.py
@@ -78,7 +78,6 @@ class Notification(CreatedModifiedAbstractModel):
             "target_user_record",
             "scheduled_delivery",
             "title",
-            "extra",
         ]
 
     def __str__(self):

--- a/django_notification_system/models/opt_out.py
+++ b/django_notification_system/models/opt_out.py
@@ -36,7 +36,7 @@ class NotificationOptOut(CreatedModifiedAbstractModel):
         verbose_name_plural = "Notification Opt Outs"
 
     def __str__(self):
-        return self.user.username
+        return str(self.user)
 
     def save(self, *args, **kwargs):
         """

--- a/django_notification_system/models/target_user_record.py
+++ b/django_notification_system/models/target_user_record.py
@@ -58,4 +58,4 @@ class TargetUserRecord(CreatedModifiedAbstractModel):
         ]
 
     def __str__(self):
-        return "{}: {}".format(self.user.username, self.description)
+        return "{}: {}".format(self.user, self.description)


### PR DESCRIPTION
There is a problem when using django-notification-system with MySQL, the problem is MySQL cannot have constraint on JSON fields.
Removing `extra` from `unique_together` solves the problem.

Note that creating another migration from changes is not an option because the first migration already fails on MySQL.